### PR TITLE
Don't fail when signals are not implemented.

### DIFF
--- a/maga.py
+++ b/maga.py
@@ -69,7 +69,11 @@ class Maga(asyncio.DatagramProtocol):
         transport, _ = self.loop.run_until_complete(coro)
 
         for signame in ('SIGINT', 'SIGTERM'):
-            self.loop.add_signal_handler(getattr(signal, signame), self.stop)
+            try:
+                self.loop.add_signal_handler(getattr(signal, signame), self.stop)
+            except NotImplementedError:
+                # SIGINT and SIGTERM are not implemented on windows
+                pass
 
         for node in self.bootstrap_nodes:
             # Bootstrap


### PR DESCRIPTION
Prevent Maga from failing during initialization on Windows, as signals are not implemented on that platform.
